### PR TITLE
Adjust vision section height and image size

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -473,7 +473,7 @@
 /* SECTION_VISION */
 
 .vision-section {
-  height: 100vh;
+  height: 100vh, max-content;
   display: flex;
   background-color: #2669A0;
   color: #FFF;
@@ -539,6 +539,7 @@
 
   .content-header {
     width: 100%;
+    height: 20rem;
     text-align: center;
     padding-right: 0;
 


### PR DESCRIPTION
The text was overlapping the size of the container at some screen sizes so I made it conditional (full viewport height or the height of the content). Also made the banner image slightly larger when changing to media query screen size.